### PR TITLE
fix: handle empty log file gracefully

### DIFF
--- a/analyse.py
+++ b/analyse.py
@@ -119,7 +119,6 @@ def main() -> None:
         )
         sys.exit(1)
 
-
     report = erstelle_report(logs)
     schreibe_json(args.output_file, report)
     print(f"Report erstellt: {len(logs)} Einträge analysiert")

--- a/analyse.py
+++ b/analyse.py
@@ -112,6 +112,14 @@ def main() -> None:
         )
         sys.exit(1)
 
+    if not logs:
+        print(
+            f"Warnung: Keine Log-Einträge in '{args.input_file}' gefunden",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
     report = erstelle_report(logs)
     schreibe_json(args.output_file, report)
     print(f"Report erstellt: {len(logs)} Einträge analysiert")


### PR DESCRIPTION
Adds early exit with warning when log file is empty, preventing ZeroDivisionError in erstelle_report.

Closes #3