### PR TITLE
feat: provision aws infrastructure with terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,12 @@ test*.json
 # Lokale Konfigurationsdateien
 overrides.json
 task-definition.json
+
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfvars
+!*.tfvars.example
+crash.log
+crash.*.log

--- a/README.md
+++ b/README.md
@@ -60,6 +60,49 @@ ruff check .
 ruff format .
 ```
 
+## Terraform
+
+Der Ordner `terraform/` enthält die komplette AWS-Infrastruktur als Code. Statt die Ressourcen einzeln per CLI anzulegen (siehe `## AWS Deployment` weiter unten als manuelle Alternative), wird hier alles deklarativ beschrieben.
+
+Provisioniert werden:
+
+- S3-Bucket (`log-analyse-paul-tf`) für Input und Output
+- ECR-Repository für das Container-Image
+- ECS-Cluster
+- CloudWatch Log Group
+- Zwei IAM-Rollen: Execution Role (für ECS selbst) und Task Role (für den Container, S3-Zugriff)
+- ECS Task Definition
+
+### Voraussetzungen
+
+- Terraform >= 1.5
+- AWS CLI mit konfiguriertem Account (`aws configure`)
+
+### Workflow
+
+```bash
+cd terraform
+terraform init     # einmalig: lädt den AWS-Provider
+terraform plan     # zeigt was angelegt wird
+terraform apply    # legt die Infrastruktur an
+```
+
+Nach erfolgreichem `apply` steht die komplette AWS-Umgebung. Container-Image bauen und pushen, Logfile hochladen, Task starten, siehe `## AWS Deployment`.
+
+### Aufräumen
+
+Nach Sessions die Ressourcen abräumen, um Kosten zu vermeiden:
+
+```bash
+terraform destroy
+```
+
+Räumt alle von Terraform verwalteten Ressourcen ab. Der Code bleibt, beim nächsten Mal stellt `terraform apply` alles in unter einer Minute wieder her.
+
+### State
+
+Der Terraform-State (`terraform.tfstate`) liegt lokal und ist via `.gitignore` ausgeschlossen. Für ein Lernprojekt ausreichend; in einem Team-Setup würde der State in einen Remote Backend (S3 + DynamoDB) ausgelagert.
+
 ## AWS Deployment
 
 Das Tool kann auch als Container in AWS ECS Fargate ausgeführt werden. Die Logdatei wird aus einem S3-Bucket gelesen und der Report nach S3 zurückgeschrieben.

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:H3mU/7URhP0uCRGK8jeQRKxx2XFzEqLiOq/L2Bbiaxs=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -1,0 +1,4 @@
+resource "aws_cloudwatch_log_group" "ecs_task" {
+  name              = "/ecs/log-analyse-task"
+  retention_in_days = 7
+}

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,0 +1,5 @@
+resource "aws_ecr_repository" "main" {
+  name                 = "log-analyse-script"
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+}

--- a/terraform/ecs.tf
+++ b/terraform/ecs.tf
@@ -1,0 +1,3 @@
+resource "aws_ecs_cluster" "main" {
+  name = "log-analyse-cluster"
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,40 @@
+
+resource "aws_iam_role" "ecs_task_execution" {
+  name = "ecsTaskExecutionRole"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role" "ecs_task_s3" {
+  name = "ecsTaskS3Role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_policy" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_s3_policy" {
+  role       = aws_iam_role.ecs_task_s3.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  required_version = ">= 1.5"
+}
+
+provider "aws" {
+  region = "eu-central-1"
+}

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,0 +1,4 @@
+resource "aws_s3_bucket" "logs" {
+  bucket = "log-analyse-paul-tf"
+  force_destroy = true
+}

--- a/terraform/task-definition.tf
+++ b/terraform/task-definition.tf
@@ -1,0 +1,26 @@
+resource "aws_ecs_task_definition" "log_analyse_task" {
+  family                   = "log-analyse-task"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
+
+  container_definitions = jsonencode([
+    {
+      name      = "log-analyse-script"
+      image     = "${aws_ecr_repository.main.repository_url}:latest"
+      essential = true
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.ecs_task.name
+          "awslogs-region"        = "eu-central-1"
+          "awslogs-stream-prefix" = "ecs"
+        }
+      }
+    }
+  ])
+
+  execution_role_arn = aws_iam_role.ecs_task_execution.arn
+  task_role_arn      = aws_iam_role.ecs_task_s3.arn
+}


### PR DESCRIPTION
- Add terraform/ directory with one file per resource type
- Provision S3 bucket, ECR repo, ECS cluster, CloudWatch log group, two IAM roles (execution + task), and ECS task definition
- Use resource references instead of hardcoded ARNs and account IDs
- Add force_destroy on S3 bucket for clean teardown
- Document workflow in README under new ## Terraform section
- Update .gitignore for terraform state files and tfvars

Closes #21